### PR TITLE
feature: add targets, remove env and nodeVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ module.exports = {
 
 ## Options
 Use this preset with customized options to extend flexibility of compilation.
-#### `nodeVersion`
+#### `targets`
 
-Default is `undefined`, will use browserslist if project specified. Ref to [babel-preset-env#targetsnode](https://babeljs.io/docs/en/babel-preset-env#targetsnode)
+Default is `undefined`. Ref to [babel-preset-env#targets](https://babeljs.io/docs/en/babel-preset-env#targets)
 #### `modules`
 
 Default is `false`, ref to [babel-preset-env#modules](https://babeljs.io/docs/en/babel-preset-env#modules)
@@ -36,7 +36,7 @@ Default is `'classic'`, Ref to [babel-preset-react#runtime](https://babeljs.io/d
 // babel.config.js
 module.exports = {
   presets: [
-    ['babel-preset-o', { modules: 'commonjs', nodeVersion: '8' }]
+    ['babel-preset-o', { modules: 'commonjs' }]
   ]  
 }
 ```

--- a/index.js
+++ b/index.js
@@ -1,24 +1,18 @@
 const path = require('path')
 
 module.exports = (api, options = {}) => {
-  const nodeEnv = process.env.NODE_ENV
-  const isTest = nodeEnv === 'test'
-  const isDev = nodeEnv === 'development'
-  const isProd = nodeEnv === 'production'
-
+  const {
+    modules = false,
+    useBuiltIns = false,
+    runtime = 'classic',
+    targets,
+  } = options
   let absoluteRuntime = null
   try {
     absoluteRuntime = path.dirname(
       require.resolve('@babel/runtime/package.json')
     )
   } catch (_) {}
-
-  const {
-    modules = false,
-    useBuiltIns = false,
-    runtime = 'classic',
-    nodeVersion,
-  } = options
 
   return {
     presets: [
@@ -29,24 +23,13 @@ module.exports = (api, options = {}) => {
           runtime,
         }
       ],
-      isTest && [
-        require('@babel/preset-env').default,
-        {
-          targets: { node: 'current' }
-        }
-      ],
-      isProd && [
+      [
         require('@babel/preset-env').default,
         {
           loose: true,
-          corejs: useBuiltIns ? 3 : false,
           modules,
           useBuiltIns,
-          // when node version is specified, use nodeVersion first,
-          // otherwise let browserslist works
-          ...(nodeVersion ? {
-            targets: { node: nodeVersion }
-          } : {}),
+          ...(targets && { targets }),
           exclude: ['@babel/plugin-transform-typeof-symbol'],
         },
       ],


### PR DESCRIPTION
* add `options.targets`, default to `undefined`.
* remove `options.nodeVersion`, use `options.targets` instead
* remove env detection, transform on any env