### PR TITLE
chore: use public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.3",
   "description": "tiny and flexible babel preset",
   "main": "index.js",
-  "repository": "git@github.com:huozhi/babel-preset-o.git",
+  "repository": "git+https://github.com/huozhi/babel-preset-o.git",
   "author": "huozhi",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Summary

- Update the package `repository` metadata from the SSH GitHub form to a public HTTPS URL.
- Leave runtime code, dependencies, package version, README, lockfile, and package entrypoint unchanged.

## Why

This repository is public, so npm consumers should be able to follow the source repository link without SSH or GitHub key setup.

## Validation

- `node -e "const p=require('./package.json'); if (p.repository !== 'git+https://github.com/huozhi/babel-preset-o.git') throw new Error(p.repository)"`
- `git diff --check`
- `pnpm install --ignore-scripts --lockfile=false`
- `pnpm pack --dry-run`

I used pnpm for local dependency installation because the local Codex runtime does not include an `npm` binary. No runtime code was changed.
